### PR TITLE
Fix minor Maven problems: set plugin version and use a non platform-dependent source encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
     <properties>
         <java.version>1.8</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Maven project is now more reliable and less verbose (it now reports no problems).

My config:
```shell
$ mvn -v
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: /usr/local/Cellar/maven-deluxe/3.6.3-0/libexec
Java version: 11.0.8, vendor: AdoptOpenJDK, runtime: /Users/nicolas/.sdkman/candidates/java/11.0.8.hs-adpt
Default locale: en_FR, platform encoding: UTF-8
OS name: "mac os x", version: "10.15.6", arch: "x86_64", family: "mac"
```

Before:
```shell
$ mvn clean test
Scanning for projects...

Some problems were encountered while building the effective model for com.gildedrose:gilded-rose-kata:jar:0.0.1-SNAPSHOT
'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 33, column 21

It is highly recommended to fix these problems because they threaten the stability of your build.

For this reason, future Maven versions might no longer support building such malformed projects.


------------------< com.gildedrose:gilded-rose-kata >-------------------
Building gilded-rose-kata 0.0.1-SNAPSHOT
--------------------------------[ jar ]---------------------------------

--- maven-clean-plugin:2.5:clean (default-clean) @ gilded-rose-kata ---
Deleting /Users/nicolas/work/gilded-rose-kata/target

--- maven-resources-plugin:2.6:resources (default-resources) @ gilded-rose-kata ---
Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
skip non existing resourceDirectory /Users/nicolas/work/gilded-rose-kata/src/main/resources

--- maven-compiler-plugin:3.1:compile (default-compile) @ gilded-rose-kata ---
Changes detected - recompiling the module!
File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
Compiling 3 source files to /Users/nicolas/work/gilded-rose-kata/target/classes

--- maven-resources-plugin:2.6:testResources (default-testResources) @ gilded-rose-kata ---
Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
skip non existing resourceDirectory /Users/nicolas/work/gilded-rose-kata/src/test/resources

--- maven-compiler-plugin:3.1:testCompile (default-testCompile) @ gilded-rose-kata ---
Changes detected - recompiling the module!
File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
Compiling 2 source files to /Users/nicolas/work/gilded-rose-kata/target/test-classes

--- maven-surefire-plugin:2.12.4:test (default-test) @ gilded-rose-kata ---
Surefire report directory: /Users/nicolas/work/gilded-rose-kata/target/surefire-reports

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.gildedrose.GildedRoseTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.197 sec

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

------------------------------------------------------------------------
BUILD SUCCESS
------------------------------------------------------------------------
Total time:  2.153 s
Finished at: 2020-09-30T08:15:39+02:00
------------------------------------------------------------------------
```

After:
```shell
$ mvn clean test
Scanning for projects...

------------------< com.gildedrose:gilded-rose-kata >-------------------
Building gilded-rose-kata 0.0.1-SNAPSHOT
--------------------------------[ jar ]---------------------------------

--- maven-clean-plugin:2.5:clean (default-clean) @ gilded-rose-kata ---
Deleting /Users/nicolas/work/gilded-rose-kata/target

--- maven-resources-plugin:2.6:resources (default-resources) @ gilded-rose-kata ---
Using 'UTF-8' encoding to copy filtered resources.
skip non existing resourceDirectory /Users/nicolas/work/gilded-rose-kata/src/main/resources

--- maven-compiler-plugin:3.8.1:compile (default-compile) @ gilded-rose-kata ---
Changes detected - recompiling the module!
Compiling 3 source files to /Users/nicolas/work/gilded-rose-kata/target/classes

--- maven-resources-plugin:2.6:testResources (default-testResources) @ gilded-rose-kata ---
Using 'UTF-8' encoding to copy filtered resources.
skip non existing resourceDirectory /Users/nicolas/work/gilded-rose-kata/src/test/resources

--- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ gilded-rose-kata ---
Changes detected - recompiling the module!
Compiling 2 source files to /Users/nicolas/work/gilded-rose-kata/target/test-classes

--- maven-surefire-plugin:2.12.4:test (default-test) @ gilded-rose-kata ---
Surefire report directory: /Users/nicolas/work/gilded-rose-kata/target/surefire-reports

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.gildedrose.GildedRoseTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.187 sec

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

------------------------------------------------------------------------
BUILD SUCCESS
------------------------------------------------------------------------
Total time:  2.222 s
Finished at: 2020-09-30T08:16:43+02:00
------------------------------------------------------------------------
```
